### PR TITLE
Documentation: add experiments section

### DIFF
--- a/EXPERIMENTS.md
+++ b/EXPERIMENTS.md
@@ -1,0 +1,44 @@
+# Experiments
+
+This document shows some further experiments that were made after the official
+paper version.
+
+## Subword embeddings
+
+We did some extensive experiments replacing all Wikipedia and Common Crawl
+embeddings (as well as character embeddings) with subword embeddings.
+
+For that purpose we use Byte-Pair Encoding (BPE) Embeddings as proposed by
+Heinzerling and Strube in
+[BPEmb: Tokenization-free Pre-trained Subword Embeddings in 275 Languages](https://arxiv.org/abs/1710.02187).
+
+For the first batch of experiments, we use a fixed dimension size of 300 and
+just change the number of merge operations. The number of merge operations are:
+1,000, 3,000, 5,000, 10,000, 25,000, 50,000, 100,000 and 200,000.
+
+### ONB dataset
+
+The current SOTA on the ONB dataset is 85.31 (reported in our paper).
+The following table shows experiments and F-Scores with Subword embeddings
+and different merge operations:
+
+| Merge operations | Run 1 | Run 2 | Run 3 | Avg. runs
+| ---------------- | ----- | ----- | ----- | ---------
+|   1,000          | 84.42 | 83.73 | 83.23 | 83.79
+|   3,000          | 81.72 | 83.75 | 85.08 | 83.52
+|   5,000          | 83.81 | 83.83 | 84.40 | 84.01
+|  10,000          | 84.58 | 84.58 | 84.55 | 84.57
+|  25,000          | 86.01 | 84.49 | 84.64 | 85.05
+|  50,000          | 85.34 | 85.27 | 84.82 | 85.14
+| 100,000          | 84.50 | 86.16 | 84.97 | **85.21**
+| 200,000          | 84.61 | 85.19 | 85.23 | 85.01
+
+Subwords embeddings with 100,000 merge operations achieve an averaged F-Score
+of 85.21 with is very close to our reported result (85.31) in our paper.
+
+Using Wipedia, Common Crawl and character embeddings has a total dimension size
+of 650 (300 + 300 + 50). Subword embeddings have only a total dimension
+size of 300. Thus, the network size is smaller and the F-Score performance is
+not negatively affected! The file size of the trained NER model decreases from
+2.7 GB to only 424 MB! Training time will also decrease from 48 minutes to
+26 minutes.

--- a/EXPERIMENTS.md
+++ b/EXPERIMENTS.md
@@ -42,3 +42,26 @@ size of 300. Thus, the network size is smaller and the F-Score performance is
 not negatively affected! The file size of the trained NER model decreases from
 2.7 GB to only 424 MB! Training time will also decrease from 48 minutes to
 26 minutes.
+
+### LFT dataset
+
+The current SOTA on the LFT dataset is 77.51 (reported in our paper).
+The following table shows experiments and F-Scores with Subword embeddings
+and different merge operations:
+
+| Merge operations | Run 1 | Run 2 | Run 3 | Avg. runs
+| ---------------- | ----- | ----- | ----- | ---------
+|   1,000          | 75.84 | 74.66 | 75.23 | 75.24
+|   3,000          | 75.02 | 75.72 | 76.10 | 75.61
+|   5,000          | 75.46 | 75.25 | 76.58 | 75.76
+|  10,000          | 75.73 | 75.46 | 76.20 | 75.80
+|  25,000          | 74.48 | 75.31 | 76.42 | 75.40
+|  50,000          | 76.34 | 75.87 | 76.66 | 76.29
+| 100,000          | 75.96 | 77.72 | 76.79 | **76.82**
+| 200,000          | 75.43 | 76.09 | 75.70 | 75.74
+
+Subword embeddings with 100,000 merge operations achieve an averaged F-Score
+of 76.82 with is -0.69 worse than our reported result (77.51) in our paper.
+
+The model size shrinks from 2.7GB to 424MB using Subword embeddings, and the
+training time decreases from 2 hours to only 1 hour.

--- a/README.md
+++ b/README.md
@@ -598,12 +598,14 @@ This outputs:
 'April Martin <B-PER> Ansclm <E-PER> , K. Gefan - gen-Auffehers Georg <B-PER> Sausgruber <E-PER> .'
 ```
 
+# Further Experiments
+
+Newer experiments (that were not covered in our paper) can be found
+[here](./EXPERIMENTS.md).
+
 # TODOs
 
-* [x] Include training script
-* [x] Show how to use our trained language models with *Flair*
 * [ ] Add BibTeX entry
-* [x] Add link to arXiv pre-print
 
 # Citing
 

--- a/README.md
+++ b/README.md
@@ -603,11 +603,23 @@ This outputs:
 Newer experiments (that were not covered in our paper) can be found
 [here](./EXPERIMENTS.md).
 
-# TODOs
-
-* [ ] Add BibTeX entry
-
 # Citing
 
 If you use our trained language models or results in your research, please use
-the following *BibTeX* entry (coming very soon).
+the following *BibTeX* entry:
+
+```bibtex
+@inproceedings{schweter-baiter-2019-towards,
+    title = "Towards Robust Named Entity Recognition for Historic {G}erman",
+    author = "Schweter, Stefan  and
+      Baiter, Johannes",
+    booktitle = "Proceedings of the 4th Workshop on Representation Learning for NLP (RepL4NLP-2019)",
+    month = aug,
+    year = "2019",
+    address = "Florence, Italy",
+    publisher = "Association for Computational Linguistics",
+    url = "https://www.aclweb.org/anthology/W19-4312",
+    pages = "96--103",
+    abstract = "In this paper we study the influence of using language model pre-training for named entity recognition for Historic German. We achieve new state-of-the-art results using carefully chosen training data for language models. For a low-resource domain like named entity recognition for Historic German, language model pre-training can be a strong competitor to CRF-only methods. We show that language model pre-training can be more effective than using transfer-learning with labeled datasets. Furthermore, we introduce a new language model pre-training objective, synthetic masked language model pre-training (SMLM), that allows a transfer from one domain (contemporary texts) to another domain (historical texts) by using only the same (character) vocabulary. Results show that using SMLM can achieve comparable results for Historic named entity recognition, even when they are only trained on contemporary texts. Our pre-trained character-based language models improve upon classical CRF-based methods and previous work on Bi-LSTMs by boosting F1 score performance by up to 6{\%}.",
+}
+```


### PR DESCRIPTION
Hi,

this PR adds a new section for further experiments, that were performed after the paper release.

Experiments with subword embeddings were done. These experiments show, that subword embeddings can reduce model size and training time. For ONB the final f-score is comparable with the paper result (that uses wikipedia, common crawl and character embeddings).

This PR also adds the BibTeX entry for our paper :heart: 